### PR TITLE
develop으로 fix-nginx-websocket merge

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -19,6 +19,11 @@ server {
 
     location / {
         proxy_pass http://node_server;
+        proxy_next_upstream error timeout invalid_header http_500 http_502 http_503 http_504;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade ${HTTP_UPGRADE};
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host ${HOST};
     }
 
     gzip on;

--- a/sample.env
+++ b/sample.env
@@ -1,2 +1,4 @@
 NGINX_SERVER_NAME=
 NGINX_HOST_REQUEST_URI=$host$request_uri
+HOST=$host
+HTTP_UPGRADE=$http_upgrade


### PR DESCRIPTION
상세 : nginx websocket 연결에 옵션 추가
proxy_http_version : websocket이 노드 백엔드와
통신할 때 HTTP 1.1을 사용
proxy_set_header : 브라우저가 http를 통해 시작하는 업그레이드 요청에 응답
sample.env에 필요한 변수 추가

close #125