### PR TITLE
develop  <- pair-webrtc-room 화요일 마무리 PR

### DIFF
--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -16,6 +16,7 @@
   "rules": {
     "linebreak-style": 0,
     "no-restricted-globals": 0,
-    "class-methods-use-this": 0
+    "class-methods-use-this": 0,
+    "no-plusplus": 0
   }
 }

--- a/server/.eslintrc.json
+++ b/server/.eslintrc.json
@@ -15,6 +15,7 @@
   },
   "rules": {
     "linebreak-style": 0,
-    "no-restricted-globals": 0
+    "no-restricted-globals": 0,
+    "class-methods-use-this": 0
   }
 }

--- a/server/app.js
+++ b/server/app.js
@@ -20,6 +20,17 @@ io.on('connection', socket => {
   socket.on('join', ({ roomNumber }) => {
     socket.join(roomNumber);
   });
+
+  socket.on('ready', ({ isReady }) => {
+    const [roomNumber] = Object.keys(socket.rooms);
+    const room = io.sockets.adapter.rooms[roomNumber];
+
+    if (isReady) {
+      room.readyUsers[socket.id] = true;
+    } else {
+      delete room.readyUsers[socket.id];
+    }
+  });
 });
 app.io = io;
 

--- a/server/app.js
+++ b/server/app.js
@@ -17,23 +17,8 @@ app.use(
 app.use(express.static(path.join(__dirname, 'public')));
 
 io.on('connection', socket => {
-  io.sockets.emit(
-    'user-joined',
-    socket.id,
-    io.engine.clientsCount,
-    Object.keys(io.sockets.clients().sockets),
-  );
-
-  socket.on('sdp', (toId, message) => {
-    io.to(toId).emit('sdp', socket.id, message);
-  });
-
-  socket.on('ice', (toId, message) => {
-    io.to(toId).emit('ice', socket.id, message);
-  });
-
-  socket.on('disconnect', () => {
-    io.sockets.emit('user-left', socket.id);
+  socket.on('join', ({ roomNumber }) => {
+    socket.join(roomNumber);
   });
 });
 app.io = io;

--- a/server/app.js
+++ b/server/app.js
@@ -2,7 +2,7 @@ const express = require('express');
 const path = require('path');
 const cookieParser = require('cookie-parser');
 const logger = require('morgan');
-const io = require('socket.io')();
+const io = require('./socket');
 
 const app = express();
 
@@ -15,23 +15,6 @@ app.use(
 );
 
 app.use(express.static(path.join(__dirname, 'public')));
-
-io.on('connection', socket => {
-  socket.on('join', ({ roomNumber }) => {
-    socket.join(roomNumber);
-  });
-
-  socket.on('ready', ({ isReady }) => {
-    const [roomNumber] = Object.keys(socket.rooms);
-    const room = io.sockets.adapter.rooms[roomNumber];
-
-    if (isReady) {
-      room.readyUsers[socket.id] = true;
-    } else {
-      delete room.readyUsers[socket.id];
-    }
-  });
-});
 app.io = io;
 
 module.exports = app;

--- a/server/config.js
+++ b/server/config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  INITIAL_ROUND: 1,
+  MIN_USER_COUNT: 2,
+  ONE_SET_SECONDS: 80,
+};

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -6,11 +6,26 @@
   </head>
 
   <body>
-    <div class="videos">
-      <div class="video-wrapper">
-        <video class="local-video" autoplay muted playsinline></video>
-      </div>
+    <div class="streaming-container hide">
+      <button class="switch-streamer-button">Switch Streamer</button>
+      <video class="streamer-video" autoplay muted playsinline></video>
     </div>
+    <input type="text" class="room-number-input"/>
+
+    <script>
+      const roomNumberInput = document.querySelector('.room-number-input');
+      const streamingContainer = document.querySelector('.streaming-container');
+      const streamerVideo = document.querySelector('.streamer-video');
+      const switchStreamerButton = document.querySelector('.switch-streamer-button');
+
+      roomNumberInput.addEventListener('keyup', (e) => {
+        if(e.keyCode == 13) {
+          streamingContainer.classList.remove('hide');
+          roomNumberInput.classList.add('hide');
+        }
+      });
+    </script>
+
     <script src="/socket.io/socket.io.js"></script>
     <script src="/javascripts/webrtc-adapter.js"></script>
     <script src="/javascripts/index.js"></script>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -12,20 +12,6 @@
     </div>
     <input type="text" class="room-number-input"/>
 
-    <script>
-      const roomNumberInput = document.querySelector('.room-number-input');
-      const streamingContainer = document.querySelector('.streaming-container');
-      const streamerVideo = document.querySelector('.streamer-video');
-      const switchStreamerButton = document.querySelector('.switch-streamer-button');
-
-      roomNumberInput.addEventListener('keyup', (e) => {
-        if(e.keyCode == 13) {
-          streamingContainer.classList.remove('hide');
-          roomNumberInput.classList.add('hide');
-        }
-      });
-    </script>
-
     <script src="/socket.io/socket.io.js"></script>
     <script src="/javascripts/webrtc-adapter.js"></script>
     <script src="/javascripts/index.js"></script>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -15,6 +15,6 @@
 
     <script src="/socket.io/socket.io.js"></script>
     <script src="/javascripts/webrtc-adapter.js"></script>
-    <script src="/javascripts/index.js"></script>
+    <script type="module" src="/javascripts/index.js"></script>
   </body>
 </html>

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -8,9 +8,10 @@
   <body>
     <div class="streaming-container hide">
       <button class="switch-streamer-button">Switch Streamer</button>
+      <button class="ready-button">Ready</button>
       <video class="streamer-video" autoplay muted playsinline></video>
     </div>
-    <input type="text" class="room-number-input"/>
+    <input type="text" class="room-number-input" />
 
     <script src="/socket.io/socket.io.js"></script>
     <script src="/javascripts/webrtc-adapter.js"></script>

--- a/server/public/javascripts/config.js
+++ b/server/public/javascripts/config.js
@@ -1,0 +1,15 @@
+export default {
+  mediaConstraints: {
+    video: true,
+    audio: false,
+  },
+
+  peerConnectionConfig: {
+    iceServers: [
+      { urls: 'stun:stun.services.mozilla.com' },
+      { urls: 'stun:stun.l.google.com:19302' },
+    ],
+  },
+
+  ENTER_KEY_CODE: 13,
+};

--- a/server/public/javascripts/index.js
+++ b/server/public/javascripts/index.js
@@ -1,4 +1,36 @@
-const socket = io();
+class SocketClient {
+
+  constructor(options) {
+    this.playerType;
+    this.localStream;
+    this.socket = io();
+    this.isReady = false;
+    this.rtcPeerConnections = [];
+    this.mediaConstraints = options.mediaConstraints;
+    this.peerConnectionConfig = options.peerConnectionConfig;
+    this.streamerVideo = document.querySelector('.streamer-video');
+    this.registerRoomJoinEvent();
+  }
+
+  registerRoomJoinEvent() {
+    const roomNumberInput = document.querySelector('.room-number-input');
+    const streamingContainer = document.querySelector('.streaming-container');
+    const switchStreamerButton = document.querySelector('.switch-streamer-button');
+    const ENTER_KEY_CODE = 13;
+
+    roomNumberInput.addEventListener('keyup', (e) => {
+      if (e.keyCode === ENTER_KEY_CODE) {
+        streamingContainer.classList.remove('hide');
+        roomNumberInput.classList.add('hide');
+        const roomNumber = roomNumberInput.value;
+        socket.emit('join', {
+          roomNumber
+        });
+      }
+    });
+  }
+
+}
 
 const mediaConstraints = {
   video: true,
@@ -15,18 +47,7 @@ const peerConnectionConfig = {
   ],
 };
 
-const roomNumberInput = document.querySelector('.room-number-input');
-const streamingContainer = document.querySelector('.streaming-container');
-const streamerVideo = document.querySelector('.streamer-video');
-const switchStreamerButton = document.querySelector('.switch-streamer-button');
-
-roomNumberInput.addEventListener('keyup', (e) => {
-  if (e.keyCode == 13) {
-    streamingContainer.classList.remove('hide');
-    roomNumberInput.classList.add('hide');
-    const roomNumber = roomNumberInput.value;
-    socket.emit('join', {
-      roomNumber
-    });
-  }
+new SocketClient({
+  mediaConstraints,
+  peerConnectionConfig
 });

--- a/server/public/javascripts/index.js
+++ b/server/public/javascripts/index.js
@@ -34,7 +34,9 @@ class SocketClient {
     const readyButton = document.querySelector('.ready-button');
 
     readyButton.addEventListener('click', () => {
-      this.socket.emit('ready', { isReady: true });
+      this.isReady = !this.isReady;
+      readyButton.innerHTML = this.isReady ? 'Cancel' : 'Ready';
+      this.socket.emit('ready', { isReady: this.isReady });
     });
   }
 }

--- a/server/public/javascripts/index.js
+++ b/server/public/javascripts/index.js
@@ -1,5 +1,4 @@
 class SocketClient {
-
   constructor(options) {
     this.playerType;
     this.localStream;
@@ -10,26 +9,34 @@ class SocketClient {
     this.peerConnectionConfig = options.peerConnectionConfig;
     this.streamerVideo = document.querySelector('.streamer-video');
     this.registerRoomJoinEvent();
+    this.registerReadyEvent();
   }
 
   registerRoomJoinEvent() {
     const roomNumberInput = document.querySelector('.room-number-input');
     const streamingContainer = document.querySelector('.streaming-container');
-    const switchStreamerButton = document.querySelector('.switch-streamer-button');
+    const switchStreamerButton = document.querySelector(
+      '.switch-streamer-button',
+    );
     const ENTER_KEY_CODE = 13;
 
-    roomNumberInput.addEventListener('keyup', (e) => {
+    roomNumberInput.addEventListener('keyup', e => {
       if (e.keyCode === ENTER_KEY_CODE) {
         streamingContainer.classList.remove('hide');
         roomNumberInput.classList.add('hide');
         const roomNumber = roomNumberInput.value;
-        this.socket.emit('join', {
-          roomNumber
-        });
+        this.socket.emit('join', { roomNumber });
       }
     });
   }
 
+  registerReadyEvent() {
+    const readyButton = document.querySelector('.ready-button');
+
+    readyButton.addEventListener('click', () => {
+      this.socket.emit('ready', { isReady: true });
+    });
+  }
 }
 
 const mediaConstraints = {
@@ -38,7 +45,8 @@ const mediaConstraints = {
 };
 
 const peerConnectionConfig = {
-  iceServers: [{
+  iceServers: [
+    {
       urls: 'stun:stun.services.mozilla.com',
     },
     {
@@ -49,5 +57,5 @@ const peerConnectionConfig = {
 
 new SocketClient({
   mediaConstraints,
-  peerConnectionConfig
+  peerConnectionConfig,
 });

--- a/server/public/javascripts/index.js
+++ b/server/public/javascripts/index.js
@@ -1,3 +1,5 @@
+import config from './config.js';
+
 class SocketClient {
   constructor(options) {
     this.playerType;
@@ -18,10 +20,9 @@ class SocketClient {
     const switchStreamerButton = document.querySelector(
       '.switch-streamer-button',
     );
-    const ENTER_KEY_CODE = 13;
 
     roomNumberInput.addEventListener('keyup', e => {
-      if (e.keyCode === ENTER_KEY_CODE) {
+      if (e.keyCode === config.ENTER_KEY_CODE) {
         streamingContainer.classList.remove('hide');
         roomNumberInput.classList.add('hide');
         const roomNumber = roomNumberInput.value;
@@ -41,23 +42,7 @@ class SocketClient {
   }
 }
 
-const mediaConstraints = {
-  video: true,
-  audio: false,
-};
-
-const peerConnectionConfig = {
-  iceServers: [
-    {
-      urls: 'stun:stun.services.mozilla.com',
-    },
-    {
-      urls: 'stun:stun.l.google.com:19302',
-    },
-  ],
-};
-
 new SocketClient({
-  mediaConstraints,
-  peerConnectionConfig,
+  mediaConstraints: config.mediaConstraints,
+  peerConnectionConfig: config.peerConnectionConfig,
 });

--- a/server/public/javascripts/index.js
+++ b/server/public/javascripts/index.js
@@ -1,7 +1,4 @@
-const localVideo = document.querySelector('.local-video');
-const rtcPeerConnections = [];
-let localStream;
-let socketId;
+const socket = io();
 
 const mediaConstraints = {
   video: true,
@@ -9,8 +6,7 @@ const mediaConstraints = {
 };
 
 const peerConnectionConfig = {
-  iceServers: [
-    {
+  iceServers: [{
       urls: 'stun:stun.services.mozilla.com',
     },
     {
@@ -19,104 +15,18 @@ const peerConnectionConfig = {
   ],
 };
 
-const getUserMediaSuccess = stream => {
-  localStream = stream;
-  localVideo.srcObject = stream;
-};
+const roomNumberInput = document.querySelector('.room-number-input');
+const streamingContainer = document.querySelector('.streaming-container');
+const streamerVideo = document.querySelector('.streamer-video');
+const switchStreamerButton = document.querySelector('.switch-streamer-button');
 
-const getRemoteStream = (event, id) => {
-  const video = document.createElement('video');
-  const wrapper = document.createElement('div');
-  const videos = document.querySelector('.videos');
-
-  wrapper.classList.add('video-wrapper');
-  video.setAttribute('data-socket', id);
-  video.srcObject = event.stream;
-  video.autoplay = true;
-  video.muted = true;
-  video.playsinline = true;
-
-  wrapper.appendChild(video);
-  videos.appendChild(wrapper);
-};
-
-const emitSdpSignal = (fromId, connections) => {
-  socket.emit('sdp', fromId, {
-    sdp: connections[fromId].localDescription,
-  });
-};
-
-const getSdpFromServer = async (fromId, message) => {
-  if (fromId !== socketId) {
-    await rtcPeerConnections[fromId].setRemoteDescription(
-      new RTCSessionDescription(message.sdp),
-    );
-    if (message.sdp.type !== 'offer') return;
-    const description = await rtcPeerConnections[fromId].createAnswer();
-    await rtcPeerConnections[fromId].setLocalDescription(description);
-    emitSdpSignal(fromId, rtcPeerConnections);
-  }
-};
-
-const getIceFromServer = async (fromId, message) => {
-  if (fromId !== socketId) {
-    rtcPeerConnections[fromId]
-      .addIceCandidate(new RTCIceCandidate(message.ice))
-      .catch(console.log);
-  }
-};
-
-const userLeftHandler = id => {
-  const video = document.querySelector(`[data-socket="${id}"]`);
-  video.parentElement.remove();
-};
-
-const spreadUserJoined = socketListId => {
-  if (rtcPeerConnections[socketListId]) return;
-  rtcPeerConnections[socketListId] = new RTCPeerConnection(
-    peerConnectionConfig,
-  );
-
-  rtcPeerConnections[socketListId].onicecandidate = () => {
-    if (event.candidate === null) return;
-    socket.emit('ice', socketListId, {
-      ice: event.candidate,
+roomNumberInput.addEventListener('keyup', (e) => {
+  if (e.keyCode == 13) {
+    streamingContainer.classList.remove('hide');
+    roomNumberInput.classList.add('hide');
+    const roomNumber = roomNumberInput.value;
+    socket.emit('join', {
+      roomNumber
     });
-  };
-
-  rtcPeerConnections[socketListId].onaddstream = () =>
-    getRemoteStream(event, socketListId);
-
-  rtcPeerConnections[socketListId].addStream(localStream);
-};
-
-const userJoinHandler = async (id, count, clients) => {
-  clients.forEach(spreadUserJoined);
-  if (count < 2) return;
-  const description = await rtcPeerConnections[id].createOffer();
-  await rtcPeerConnections[id].setLocalDescription(description);
-  emitSdpSignal(id, rtcPeerConnections);
-};
-
-const initSocketId = () => {
-  socketId = socket.id;
-};
-
-const runWebRTC = async () => {
-  if (!navigator.mediaDevices.getUserMedia) {
-    alert('Your browser does not support getUserMedia API');
-  } else {
-    const stream = await navigator.mediaDevices.getUserMedia(mediaConstraints);
-    getUserMediaSuccess(stream);
   }
-
-  socket = io();
-
-  socket.on('sdp', getSdpFromServer);
-  socket.on('ice', getIceFromServer);
-  socket.on('user-left', userLeftHandler);
-  socket.on('user-joined', userJoinHandler);
-  socket.on('connect', initSocketId);
-};
-
-runWebRTC();
+});

--- a/server/public/javascripts/index.js
+++ b/server/public/javascripts/index.js
@@ -23,7 +23,7 @@ class SocketClient {
         streamingContainer.classList.remove('hide');
         roomNumberInput.classList.add('hide');
         const roomNumber = roomNumberInput.value;
-        socket.emit('join', {
+        this.socket.emit('join', {
           roomNumber
         });
       }

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -4,6 +4,8 @@ const webRtcUtils = require('./utils');
 io.on('connection', socket => {
   socket.on('join', ({ roomNumber }) => {
     socket.join(roomNumber);
+    const room = io.sockets.adapter.rooms[roomNumber];
+    room.readyUsers = room.readyUsers || {};
   });
 
   socket.on('ready', ({ isReady }) => {

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -13,6 +13,7 @@ io.on('connection', socket => {
   }) => {
     const [roomNumber] = Object.keys(socket.rooms);
     const room = io.sockets.adapter.rooms[roomNumber];
+    const socketIds = Object.keys(room.sockets);
 
     if (isReady) {
       room.readyUsers[socket.id] = true;
@@ -20,10 +21,8 @@ io.on('connection', socket => {
       delete room.readyUsers[socket.id];
     }
 
-    const socketIds = Object.keys(room.sockets);
-    const readyUsers = Object.keys(room.readyUsers);
 
-    if (socketIds.length === readyUsers.length) {
+    if (webRtcUtils.checkAllReady(room)) {
       const streamerIndex = 0;
       webRtcUtils.distributePlayerTypes(io, streamerIndex, socketIds)
     }

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -1,5 +1,6 @@
 const io = require('socket.io')();
 const webRtcUtils = require('./utils');
+const config = require('../config');
 
 io.on('connection', socket => {
   socket.on('join', ({ roomNumber }) => {
@@ -12,7 +13,6 @@ io.on('connection', socket => {
     const [roomNumber] = Object.keys(socket.rooms);
     const room = io.sockets.adapter.rooms[roomNumber];
     const socketIds = Object.keys(room.sockets);
-    const minUserCount = 2;
 
     if (isReady) {
       room.readyUsers[socket.id] = true;
@@ -22,12 +22,15 @@ io.on('connection', socket => {
 
     if (
       webRtcUtils.checkAllReady(room) &&
-      room.readyUsers.length >= minUserCount
+      room.readyUsers.length >= config.MIN_USER_COUNT
     ) {
-      const setCount = 80;
       room.gameStatus =
         room.gameStatus ||
-        webRtcUtils.makeGameStatus(socketIds, roomNumber, setCount);
+        webRtcUtils.makeGameStatus(
+          socketIds,
+          roomNumber,
+          config.ONE_SET_SECONDS,
+        );
       webRtcUtils.distributePlayerTypes(
         io,
         room.gameStatus.gameOrderQueue.shift(),

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -1,0 +1,34 @@
+const io = require('socket.io')();
+const webRtcUtils = require('./utils');
+
+io.on('connection', socket => {
+  socket.on('join', ({
+    roomNumber
+  }) => {
+    socket.join(roomNumber);
+  });
+
+  socket.on('ready', ({
+    isReady
+  }) => {
+    const [roomNumber] = Object.keys(socket.rooms);
+    const room = io.sockets.adapter.rooms[roomNumber];
+
+    if (isReady) {
+      room.readyUsers[socket.id] = true;
+    } else {
+      delete room.readyUsers[socket.id];
+    }
+
+    const socketIds = Object.keys(room.sockets);
+    const readyUsers = Object.keys(room.readyUsers);
+
+    if (socketIds.length === readyUsers.length) {
+      const streamerIndex = 0;
+      webRtcUtils.distributePlayerTypes(io, streamerIndex, socketIds)
+    }
+
+  });
+});
+
+module.exports = io;

--- a/server/socket/index.js
+++ b/server/socket/index.js
@@ -21,10 +21,10 @@ io.on('connection', socket => {
       delete room.readyUsers[socket.id];
     }
 
-
     if (webRtcUtils.checkAllReady(room)) {
-      const streamerIndex = 0;
-      webRtcUtils.distributePlayerTypes(io, streamerIndex, socketIds)
+      const setCount = 80;
+      room.gameStatus = room.gameStatus || webRtcUtils.makeGameStatus(socketIds, roundNumber, setCount);
+      webRtcUtils.distributePlayerTypes(io, gameStatus.gameOrderQueue.shift(), socketIds);
     }
 
   });

--- a/server/socket/utils.js
+++ b/server/socket/utils.js
@@ -1,7 +1,7 @@
 module.exports = {
-  distributePlayerTypes(io, streamerId, socketIds) {
+  distributePlayerTypes(io, streamer, socketIds) {
     socketIds.forEach(socketId => {
-      if (streamerId === socketId) {
+      if (streamer.socketId === socketId) {
         io.to(socketId).emit('playerType:streamer');
       } else {
         io.to(socketId).emit('playerType:viewer');
@@ -41,6 +41,18 @@ module.exports = {
     const socketIds = Object.keys(room.sockets);
     const readyUsers = Object.keys(room.readyUsers);
     return socketIds.length === readyUsers.length;
-  }
+  },
+
+  makeGameStatus(socketIds, roundNumber, count) {
+    const initialRound = 1;
+    const initialGameStatus = {
+      gameOrderQueue: makeGameOrderQueue(socketIds, roundNumber),
+      currentStreamer: this.gameOrderQueue[0],
+      currentCount: count,
+      isPlaying: true,
+      currentRound: initialRound,
+    }
+    return initialGameStatus;
+  },
 
 };

--- a/server/socket/utils.js
+++ b/server/socket/utils.js
@@ -8,4 +8,17 @@ module.exports = {
       }
     });
   },
+
+  makeGameOrderQueue(socketIds, roundNumber) {
+    const gameOrderQueue = [];
+    const roundQueue = socketIds.map(socketId => {
+      return { type: 'player', socketId };
+    });
+
+    for (let i = 0; i < roundNumber; i += 1) {
+      gameOrderQueue.push(...roundQueue);
+      gameOrderQueue.push({ type: 'roundEnd', round: i + 1 });
+    }
+    gameOrderQueue.push({ type: 'gameEnd' });
+  },
 };

--- a/server/socket/utils.js
+++ b/server/socket/utils.js
@@ -12,13 +12,29 @@ module.exports = {
   makeGameOrderQueue(socketIds, roundNumber) {
     const gameOrderQueue = [];
     const roundQueue = socketIds.map(socketId => {
-      return { type: 'player', socketId };
+      return {
+        type: 'player',
+        socketId
+      };
     });
 
     for (let i = 0; i < roundNumber; i += 1) {
       gameOrderQueue.push(...roundQueue);
-      gameOrderQueue.push({ type: 'roundEnd', round: i + 1 });
+      gameOrderQueue.push({
+        type: 'roundEnd',
+        round: i + 1
+      });
     }
-    gameOrderQueue.push({ type: 'gameEnd' });
+    gameOrderQueue.push({
+      type: 'gameEnd'
+    });
+    return gameOrderQueue;
   },
+
+  filterGameOrderQueue(targetSocketId, gameOrderQueue) {
+    return gameOrderQueue.filter(player => {
+      return player.socketId !== targetSocketId
+    });
+  },
+
 };

--- a/server/socket/utils.js
+++ b/server/socket/utils.js
@@ -1,0 +1,13 @@
+module.exports = {
+
+  distributePlayerTypes(io, streamerIndex, socketIds) {
+    socketIds.forEach((socketId, i) => {
+      if (i === streamerIndex) {
+        io.to(socketId).emit('playerType:streamer');
+      } else {
+        io.to(socketId).emit('playerType:viewer');
+      }
+    });
+  }
+
+}

--- a/server/socket/utils.js
+++ b/server/socket/utils.js
@@ -1,13 +1,11 @@
 module.exports = {
-
-  distributePlayerTypes(io, streamerIndex, socketIds) {
-    socketIds.forEach((socketId, i) => {
-      if (i === streamerIndex) {
+  distributePlayerTypes(io, streamerId, socketIds) {
+    socketIds.forEach(socketId => {
+      if (streamerId === socketId) {
         io.to(socketId).emit('playerType:streamer');
       } else {
         io.to(socketId).emit('playerType:viewer');
       }
     });
-  }
-
-}
+  },
+};

--- a/server/socket/utils.js
+++ b/server/socket/utils.js
@@ -1,3 +1,5 @@
+const config = require('../config');
+
 module.exports = {
   distributePlayerTypes(io, streamer, socketIds) {
     socketIds.forEach(socketId => {
@@ -12,29 +14,19 @@ module.exports = {
   makeGameOrderQueue(socketIds, roundNumber) {
     const gameOrderQueue = [];
     const roundQueue = socketIds.map(socketId => {
-      return {
-        type: 'player',
-        socketId
-      };
+      return { type: 'player', socketId };
     });
 
-    for (let i = 0; i < roundNumber; i += 1) {
+    for (let i = 0; i < roundNumber; i++) {
       gameOrderQueue.push(...roundQueue);
-      gameOrderQueue.push({
-        type: 'roundEnd',
-        round: i + 1
-      });
+      gameOrderQueue.push({ type: 'roundEnd', round: i + 1 });
     }
-    gameOrderQueue.push({
-      type: 'gameEnd'
-    });
+    gameOrderQueue.push({ type: 'gameEnd' });
     return gameOrderQueue;
   },
 
   filterGameOrderQueue(targetSocketId, gameOrderQueue) {
-    return gameOrderQueue.filter(player => {
-      return player.socketId !== targetSocketId
-    });
+    return gameOrderQueue.filter(player => player.socketId !== targetSocketId);
   },
 
   checkAllReady(room) {
@@ -44,15 +36,13 @@ module.exports = {
   },
 
   makeGameStatus(socketIds, roundNumber, count) {
-    const initialRound = 1;
     const initialGameStatus = {
-      gameOrderQueue: makeGameOrderQueue(socketIds, roundNumber),
+      gameOrderQueue: this.makeGameOrderQueue(socketIds, roundNumber),
       currentStreamer: this.gameOrderQueue[0],
       currentCount: count,
       isPlaying: true,
-      currentRound: initialRound,
-    }
+      currentRound: config.INITIAL_ROUND,
+    };
     return initialGameStatus;
   },
-
 };

--- a/server/socket/utils.js
+++ b/server/socket/utils.js
@@ -37,4 +37,10 @@ module.exports = {
     });
   },
 
+  checkAllReady(room) {
+    const socketIds = Object.keys(room.sockets);
+    const readyUsers = Object.keys(room.readyUsers);
+    return socketIds.length === readyUsers.length;
+  }
+
 };


### PR DESCRIPTION
# Pull Request

## What

- webRTC 게임 룸 관련 로직 구현
  - 클라이언트에서 ready 정보를 보내면 서버에서 room 마다 readyUsers를 유지
  - 게임 시작 전에 gameOrderQueue를 생성
     - gameOrderQueue에는 출제자 순서, Round종료, Game종료등의 정보가 포함됨
  - room에 속한 모든 인원이 전부 ready상태일 경우 게임이 시작됨
     - room에는 gameStatus라는 정보를 유지함
        - gameOrderQueue
        - currentStreamer
        - currentCount
        - isPlaying
        - currentRound
     - 최소인원 점검 기능 구현 (최소 2인)
     - room에 가장 처음으로 접속한 사람에게 출제자임을 알리는 이벤트 전송
     - 나머지 인원에게는 도전자임을 알리는 이벤트 전송

## Why
- socket으로 단순히 방에 입장하는 것이 아니라 게임 준비를 위한 여러 로직이 필요함

## Etc.
- eslint rule 변경사항
  - no-plusplus 무효화
  - class-methods-use-this 무효화