### PR TITLE
[ develop <- fix-gitignore ] gitignore에 client/build 디렉토리 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -183,6 +183,7 @@ $RECYCLE.BIN/
 # dependencies
 /.pnp
 .pnp.js
+build/
 
 # testing
 


### PR DESCRIPTION


# Pull Request

## What
- .gitignore에 client/build 디렉토리 추가

## Why
- react build가 실행시 생성되는 코드가 저장되는 디렉토리임
- 서버의 public이 build 디렉토리와 매핑되어 있음
- docker에서 build를 실행하여 배포하는 로직이 이미 존재하고 있음
- 직접 생성한 코드가 아닌이상 커밋할 필요가 없음

## Etc.
- related issue #239
- build 브랜치를 생성하여 빌드를 유지하는 것도 생각해 볼 수도 있음