### PR TITLE
[develop <- ios-video-bug-fix] video 태그에 빠져있던 playsInline 옵션 추가

### DIFF
--- a/client/src/presentation/components/StreamerVideo.jsx
+++ b/client/src/presentation/components/StreamerVideo.jsx
@@ -20,7 +20,7 @@ const StreamerVideo = ({ stream }) => {
     videoElement.srcObject = stream;
   }, []);
 
-  return <video className={classes.video} autoPlay ref={ref} />;
+  return <video className={classes.video} autoPlay playsInline ref={ref} />;
 };
 
 StreamerVideo.propTypes = {


### PR DESCRIPTION
# Pull Request

## What
- video태그를 react로 옮겨오면서 누락된
playsInline 옵션을 추가

## Why
- 아이폰에서 video를 자동 재생 하기 위함

## Etc.
- video태그에 playslnline옵션을 추가함으로써 ios 모바일 기기에서 video controller가 반전되어 보이던 현상도 해결됨
