### PR TITLE
[develop <- quiz-reselect-fix] 퀴즈 이중선택 방지 및 부정한 퀴즈 선택 방지

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -19,4 +19,7 @@ module.exports = {
   PING_INTERVAL: 1000,
   PING_TIMEOUT: 5000,
   NICKNAME_LENGTH: 8,
+  GAME_PLAYING: 'playing',
+  GAME_INITIALIZING: 'initializing',
+  QUIZ_NOT_SELECTED: '',
 };

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -5,6 +5,9 @@ const {
   ONE_SET_SECONDS,
   SECONDS_BETWEEN_SETS,
   SECONDS_AFTER_GAME_END,
+  GAME_INITIALIZING,
+  GAME_PLAYING,
+  QUIZ_NOT_SELECTED,
 } = require('../../../config');
 
 const sendCurrentSecondsHandler = (currentSeconds, roomId) => {
@@ -48,12 +51,12 @@ const endSet = (gameManager, timer) => {
 const startSet = (gameManager, timer, quiz) => {
   timer.clear();
   gameManager.setQuiz(quiz);
-  gameManager.setStatus('playing');
+  gameManager.setStatus(GAME_PLAYING);
   gameManager.getPlayers().forEach(player => {
     const socketId = player.getSocketId();
     io.to(socketId).emit('clearWindow');
     io.to(socketId).emit('startSet', {
-      quiz: gameManager.isStreamer(socketId) ? quiz : '',
+      quiz: gameManager.isStreamer(socketId) ? quiz : QUIZ_NOT_SELECTED,
       quizLength: quiz.length,
     });
   });
@@ -75,12 +78,13 @@ const prepareSet = (gameManager, timer) => {
   /**
    * 연결준비 후 응답이 없는 플레이어를 제외하고 시작
    */
-  gameManager.setQuiz('');
+  gameManager.setQuiz(QUIZ_NOT_SELECTED);
   /**
    * @todo 추후 DB 연결시 async await 필요
    */
   const quizCandidates = pickQuizCandidates();
   gameManager.setQuizCandidates(quizCandidates);
+  gameManager.setStatus(GAME_INITIALIZING);
   gameManager.getPlayers().forEach(player => {
     const socketId = player.getSocketId();
 

--- a/server/service/game/eventHandlers/selectQuizHandler.js
+++ b/server/service/game/eventHandlers/selectQuizHandler.js
@@ -19,11 +19,13 @@ const isQuizInQuizCandidates = (quizCandidates, quiz) => {
 const selectQuizHandler = (socket, { quiz }) => {
   const { gameManager, timer } = roomController.getRoomByRoomId(socket.roomId);
   /**
+   * 전송자가 스트리머인지,
    * 게임의 상태가 단어 선택 단계인지,
    * 퀴즈의 단어가 선택됐는지,
    * 마지막으로 퀴즈의 단어가 목록에 있는지 확인하는 로직
    */
   if (
+    gameManager.isStreamer(socket.id) &&
     isGameInitializing(gameManager.getStatus()) &&
     quizNotSelected(gameManager.getQuiz()) &&
     isQuizInQuizCandidates(gameManager.getQuizCandidates(), quiz)

--- a/server/service/game/eventHandlers/selectQuizHandler.js
+++ b/server/service/game/eventHandlers/selectQuizHandler.js
@@ -1,9 +1,35 @@
 const roomController = require('../controllers/roomController');
 const gameController = require('../controllers/gameController');
+const { GAME_INITIALIZING, QUIZ_NOT_SELECTED } = require('../../../config');
+
+const isGameInitializing = status => {
+  return status === GAME_INITIALIZING;
+};
+
+const quizNotSelected = quiz => {
+  return quiz === QUIZ_NOT_SELECTED;
+};
+
+const isQuizInQuizCandidates = (quizCandidates, quiz) => {
+  return quizCandidates.find(quizCandidate => {
+    return quizCandidate === quiz;
+  });
+};
 
 const selectQuizHandler = (socket, { quiz }) => {
   const { gameManager, timer } = roomController.getRoomByRoomId(socket.roomId);
-  gameController.startSet(gameManager, timer, quiz);
+  /**
+   * 게임의 상태가 단어 선택 단계인지,
+   * 퀴즈의 단어가 선택됐는지,
+   * 마지막으로 퀴즈의 단어가 목록에 있는지 확인하는 로직
+   */
+  if (
+    isGameInitializing(gameManager.getStatus()) &&
+    quizNotSelected(gameManager.getQuiz()) &&
+    isQuizInQuizCandidates(gameManager.getQuizCandidates(), quiz)
+  ) {
+    gameController.startSet(gameManager, timer, quiz);
+  }
 };
 
 module.exports = selectQuizHandler;


### PR DESCRIPTION
# Pull Request

## What

- 퀴즈 선택에 대한 검증 로직 추가
- prepareSet을 할 때 서버측의 status를 initializing으로 변경
- 변수들의 값을 config로 외부화

## Why

- 게임 퀴즈 선택에 대한 검증 필요(게임 중 단어 선정 금지 등)

## Etc.

- 변수들의 외부화(config로 게임 상태 외부화 등) 이를 기반으로 다른 매직넘버들도 제거하면
좋을 것이라 판단
