### PR TITLE
[develop <- fix-endset-message-error] 퀴즈 고르는 중에 스트리머가 나가 세트가 끝나면 뷰어에게 메세지가 사라지지 않는 버그 해결

### DIFF
--- a/client/src/service/GameManager.js
+++ b/client/src/service/GameManager.js
@@ -53,6 +53,7 @@ class GameManager {
     this.dispatch(actions.setCurrentSeconds(0));
     this.dispatch(actions.setQuiz('', 0));
     this.dispatch(actions.setChattingDisabled(false));
+    this.dispatch(actions.clearWindow());
     this.dispatch(
       actions.setScoreNotice({
         isVisible: true,

--- a/client/src/store/globalReducer.js
+++ b/client/src/store/globalReducer.js
@@ -83,7 +83,7 @@ const reducer = (state, action) => {
       return {
         ...initialState,
       };
-    case 'clearWindow':
+    case TYPES.CLEAR_WINDOW:
       return {
         ...state,
         messageNotice: {


### PR DESCRIPTION
# Pull Request

## What
- 클라이언트 endSet 이벤트에 clearWindow를 콜하여 해결


