### PR TITLE
[develop <- ban-disconnected-player] 게임 중 카메라 연결이 안 될 경우, 플레이어 추방

### DIFF
--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -54,6 +54,9 @@ const pickQuizCandidates = async () => {
 };
 
 const endSet = (gameManager, timer) => {
+  gameManager.getPlayers().forEach(player => {
+    player.setIsConnectedToStreamer(false);
+  })
   io.in(gameManager.getRoomId()).emit('endSet', {
     scoreList: gameManager.getScoreList(),
   });

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -133,8 +133,7 @@ const disconnectPlayersAndStartGame = (gameManager, timer) => {
 
   // 스트리머가 카메라 허용을 하지 않았을 경우
   if (playersToDisconnect.length === playersExceptStreamer.length) {
-    const socket =
-      io.sockets.connected[gameManager.getStreamer().getSocketId()];
+    const socket = io.sockets.connected[streamer.getSocketId()];
     socket.disconnect();
     return;
   }

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -137,19 +137,19 @@ const disconnectPlayersAndStartGame = (gameManager, timer) => {
     const socket =
       io.sockets.connected[gameManager.getStreamer().getSocketId()];
     socket.disconnect();
-  } else {
-    // 스트리머 이외의 사람 중 카메라 허용을 안하는 경우가 있을 경우
-    playersToDisconnect.forEach(player => {
-      const socket = io.sockets.connected[player.getSocketId()];
-      socket.disconnect();
-    });
-    /**
-     * 이후에 게임을 진행할 수 있으면, disconnectingHandler쪽에서는 처리하지 않으므로
-     * 해당 로직에서 게임을 진행한다.
-     */
-    if (gameManager.isGameContinuable()) {
-      prepareSet(gameManager, timer);
-    }
+    return;
+  }
+  // 스트리머 이외의 사람 중 카메라 허용을 안하는 경우가 있을 경우
+  playersToDisconnect.forEach(player => {
+    const socket = io.sockets.connected[player.getSocketId()];
+    socket.disconnect();
+  });
+  /**
+   * 이후에 게임을 진행할 수 있으면, disconnectingHandler쪽에서는 처리하지 않으므로
+   * 해당 로직에서 게임을 진행한다.
+   */
+  if (gameManager.isGameContinuable()) {
+    prepareSet(gameManager, timer);
   }
 };
 

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -131,14 +131,14 @@ const disconnectPlayersAndStartGame = (gameManager, timer) => {
   );
   const playersToDisconnect = gameManager.getPlayersUnconnectedToStreamer();
 
-  //스트리머가 카메라 허용을 하지 않았을 경우
+  // 스트리머가 카메라 허용을 하지 않았을 경우
   console.log('players to disconnect Length : ', playersToDisconnect.length);
   if (playersToDisconnect.length === playersExceptStreamer.length) {
     const socket =
       io.sockets.connected[gameManager.getStreamer().getSocketId()];
     socket.disconnect();
   } else {
-    //스트리머 이외의 사람 중 카메라 허용을 안하는 경우가 있을 경우
+    // 스트리머 이외의 사람 중 카메라 허용을 안하는 경우가 있을 경우
     playersToDisconnect.forEach(player => {
       const socket = io.sockets.connected[player.getSocketId()];
       socket.disconnect();

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -132,7 +132,6 @@ const disconnectPlayersAndStartGame = (gameManager, timer) => {
   const playersToDisconnect = gameManager.getPlayersUnconnectedToStreamer();
 
   // 스트리머가 카메라 허용을 하지 않았을 경우
-  console.log('players to disconnect Length : ', playersToDisconnect.length);
   if (playersToDisconnect.length === playersExceptStreamer.length) {
     const socket =
       io.sockets.connected[gameManager.getStreamer().getSocketId()];

--- a/server/service/game/models/GameManager.js
+++ b/server/service/game/models/GameManager.js
@@ -157,7 +157,8 @@ class GameManager {
   }
 
   getPlayersUnconnectedToStreamer() {
-    return this.players.filter(player => !player.getIsConnectedToStreamer());
+    const viewers = this.getOtherPlayers(this.getStreamer().getSocketId());
+    return viewers.filter(viewer => !viewer.getIsConnectedToStreamer());
   }
 
   checkAllConnectionsToStreamer() {


### PR DESCRIPTION
# Pull Request

## What

- 스트리머에서 영상을 송출하지 않을 경우, 내보내는 기능 구현
- 스트리머의 영상을 받지 못한 플레이어의 경우, 내보내는 기능 구현
- 스트리머의 정보 전송은
  - 모든 사람이 받지 못할 경우 : 스트리머가 영상을 전송하지 않은 것
  - 몇몇 사람이 받은 경우 : 스트리머가 영상을 전송하지만 몇몇은 받지 않은 것
  으로 판단.

## Why

- 기존의 로직에서 스트리머가 영상을 전송했고, 플레이어가 받았는지 확인은
`connectPeer` 이벤트에서만 확인 가능. 그렇기에 해당 이벤트를 활용해서
사용자가 받았는지, 아니면 스트리머가 보냈는지 여부를 확인.
