### PR TITLE
[develop <- round-set-visualize] 중간 점수 단계에 라운드와 세트 표기

### DIFF
--- a/client/src/config.js
+++ b/client/src/config.js
@@ -22,10 +22,9 @@ const MOBILE_PANEL_HEIGHT = '50%';
 
 const LOCALSTORAGE_NICKNAME_KEY = 'trycatch-nickname';
 
-
 const SOCKETIO_SERVER_URL =
   process.env.NODE_ENV === 'development' ? 'localhost:3001' : '';
-const GAME_END_SCOREBOARD_TITLE = '최종 점수';
+const GAME_END_SCOREBOARD_TITLE = '게임 종료';
 
 export {
   MainIntroductionDescription,

--- a/client/src/service/GameManager.js
+++ b/client/src/service/GameManager.js
@@ -48,7 +48,7 @@ class GameManager {
     this.dispatch(actions.clearWindow());
   }
 
-  endSetHandler({ scoreList }) {
+  endSetHandler({ currentRound, currentSet, scoreList }) {
     this.dispatch(actions.setGameStatus('scoreSharing'));
     this.dispatch(actions.setCurrentSeconds(0));
     this.dispatch(actions.setQuiz('', 0));
@@ -57,7 +57,7 @@ class GameManager {
     this.dispatch(
       actions.setScoreNotice({
         isVisible: true,
-        message: '중간 점수',
+        message: `${currentRound} - ${currentSet}`,
         scoreList,
       }),
     );

--- a/server/config.js
+++ b/server/config.js
@@ -21,6 +21,7 @@ module.exports = {
   NICKNAME_LENGTH: 8,
   GAME_PLAYING: 'playing',
   GAME_INITIALIZING: 'initializing',
+  GAME_INITIAL_PREPARING: 'initialPreparing',
   QUIZ_NOT_SELECTED: '',
   INVALID_DATE: 'Invalid Date',
 };

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -55,6 +55,8 @@ const pickQuizCandidates = async () => {
 
 const endSet = (gameManager, timer) => {
   io.in(gameManager.getRoomId()).emit('endSet', {
+    currentRound: gameManager.getCurrentRound(),
+    currentSet: gameManager.getCurrentSet(),
     scoreList: gameManager.getScoreList(),
   });
 

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -137,6 +137,7 @@ const waitForPeerConnection = (gameManager, timer) => {
 };
 
 const preparePlayerTypes = gameManager => {
+  gameManager.updateRoundAndSet();
   gameManager.selectStreamer();
   assignPlayerType(gameManager);
 };
@@ -153,7 +154,6 @@ const prepareGame = (gameManager, timer) => {
   gameManager.prepareGame();
   io.in(gameManager.getRoomId()).emit('startGame');
 
-  gameManager.updateRoundAndSet();
   preparePlayerTypes(gameManager);
   waitForPeerConnection(gameManager, timer);
 };
@@ -210,7 +210,6 @@ const resetGameAfterNSeconds = ({ seconds, gameManager, timer }) => {
 };
 
 const repeatSet = (gameManager, timer) => {
-  gameManager.updateRoundAndSet();
   if (gameManager.isGameContinuable()) {
     endSet(gameManager, timer);
     goToNextSetAfterNSeconds({

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -5,7 +5,6 @@ const {
   ONE_SET_SECONDS,
   SECONDS_BETWEEN_SETS,
   SECONDS_AFTER_GAME_END,
-  GAME_INITIALIZING,
   GAME_PLAYING,
   QUIZ_NOT_SELECTED,
 } = require('../../../config');
@@ -93,13 +92,13 @@ const prepareSet = async (gameManager, timer) => {
   /**
    * 연결준비 후 응답이 없는 플레이어를 제외하고 시작
    */
+  gameManager.updateRoundAndSet();
   gameManager.setQuiz(QUIZ_NOT_SELECTED);
   /**
    * @todo 추후 DB 연결시 async await 필요
    */
   const quizCandidates = await pickQuizCandidates();
   gameManager.setQuizCandidates(quizCandidates);
-  gameManager.setStatus(GAME_INITIALIZING);
   gameManager.getPlayers().forEach(player => {
     const socketId = player.getSocketId();
 
@@ -137,7 +136,6 @@ const waitForPeerConnection = (gameManager, timer) => {
 };
 
 const preparePlayerTypes = gameManager => {
-  gameManager.updateRoundAndSet();
   gameManager.selectStreamer();
   assignPlayerType(gameManager);
 };

--- a/server/service/game/eventHandlers/connectPeerHandler.js
+++ b/server/service/game/eventHandlers/connectPeerHandler.js
@@ -1,5 +1,6 @@
 const roomController = require('../controllers/roomController');
 const gameController = require('../controllers/gameController');
+const { GAME_INITIALIZING } = require('../../../config');
 
 const connectPeerHandler = socket => {
   const { gameManager, timer } = roomController.getRoomByRoomId(socket.roomId);
@@ -8,11 +9,13 @@ const connectPeerHandler = socket => {
 
   if (
     gameManager.getStreamer() &&
-    gameManager.checkAllConnectionsToStreamer()
+    gameManager.checkAllConnectionsToStreamer() &&
+    gameManager.getStatus() !== GAME_INITIALIZING
   ) {
     /**
      * 연결 준비 후 정상 시작
      */
+    gameManager.setStatus(GAME_INITIALIZING);
     timer.clear();
     gameController.prepareSet(gameManager, timer);
   }

--- a/server/service/game/eventHandlers/disconnectingHandler.js
+++ b/server/service/game/eventHandlers/disconnectingHandler.js
@@ -3,7 +3,9 @@ const roomController = require('../controllers/roomController');
 const gameController = require('../controllers/gameController');
 const {
   SECONDS_AFTER_GAME_END,
-  SECONDS_BETWEEN_SETS,
+  GAME_PLAYING,
+  GAME_INITIALIZING,
+  GAME_INITIAL_PREPARING,
   MIN_PLAYER_COUNT,
 } = require('../../../config');
 
@@ -32,7 +34,11 @@ const disconnectingHandler = socket => {
       return;
     }
 
-    if (roomStatus === 'initializing' || roomStatus === 'playing') {
+    if (
+      roomStatus === GAME_INITIALIZING ||
+      roomStatus === GAME_PLAYING ||
+      roomStatus === GAME_INITIAL_PREPARING
+    ) {
       if (!gameManager.isGameContinuable()) {
         gameController.endGame(gameManager, timer);
         gameController.resetGameAfterNSeconds({

--- a/server/service/game/models/GameManager.js
+++ b/server/service/game/models/GameManager.js
@@ -1,4 +1,8 @@
-const { MAX_ROUND_NUMBER, MIN_PLAYER_COUNT } = require('../../../config');
+const {
+  MAX_ROUND_NUMBER,
+  MIN_PLAYER_COUNT,
+  GAME_INITIAL_PREPARING,
+} = require('../../../config');
 
 class GameManager {
   constructor(roomId) {
@@ -88,6 +92,7 @@ class GameManager {
   prepareGame() {
     this.reset();
     this.setStreamerCandidates();
+    this.status = GAME_INITIAL_PREPARING;
   }
 
   updateRoundAndSet() {

--- a/server/service/game/models/GameManager.js
+++ b/server/service/game/models/GameManager.js
@@ -88,7 +88,6 @@ class GameManager {
   prepareGame() {
     this.reset();
     this.setStreamerCandidates();
-    this.status = 'initializing';
   }
 
   updateRoundAndSet() {


### PR DESCRIPTION
# Pull Request

## What

- 중간 점수 대신 라운드와 세트 표시
- 한 세트에 한번의 updateAndRound만 하도록 변경
(prepareSet에 포함시킴)

## Etc.

- 한 세트에 여러번 prepareSet이 진행되는 문제 발견
  - 해당 문제의 원인은 connectPeerHandler 내부의 prepareSet이 여러번 불리기 때문. 게임룸에 상태를 하나 추가시킴으로 문제 해결.
