### PR TITLE
[develop <- fix-duplicate-answer] 정답을 맞힌 유저는 더이상 정답을 맞힐 수 없도록 수정

### DIFF
--- a/client/src/presentation/containers/ChattingPanel.jsx
+++ b/client/src/presentation/containers/ChattingPanel.jsx
@@ -38,7 +38,7 @@ const ChattingPanel = ({ clientManager }) => {
       </Box>
       <InputWindow
         clientManager={clientManager}
-        isChattingDisabled={chattingDisabled}
+        chattingDisabled={chattingDisabled}
       />
     </Box>
   );

--- a/server/service/game/eventHandlers/sendChattingMessageHandler.js
+++ b/server/service/game/eventHandlers/sendChattingMessageHandler.js
@@ -24,13 +24,19 @@ const sendChattingMessageHandler = (socket, { message }) => {
   const player = gameManager.getPlayerBySocketId(socket.id);
   const playerNickname = player.getNickname();
 
-  if (isCorrectAnswer(gameManager, message, socket.id)) {
+  if (player.getIsCorrectPlayer()) return;
+
+  if (
+    isCorrectAnswer(gameManager, message, socket.id) &&
+    gameManager.getStatus() === 'playing'
+  ) {
     io.in(socket.roomId).emit('sendChattingMessage', {
       nickname: '안내',
       message: `${playerNickname}님이 정답을 맞췄습니다!`,
       nicknameColor: '#000000',
       id: short.generate(),
     });
+
     const score = player.getScore() + timer.getRemainingTime() + 50;
     player.setScore(score);
     player.setIsCorrectPlayer(true);
@@ -42,6 +48,7 @@ const sendChattingMessageHandler = (socket, { message }) => {
     }
     return;
   }
+
   const processedChat = processChatWithSystemRule(message);
   if (processedChat) {
     io.in(socket.roomId).emit('sendChattingMessage', {


### PR DESCRIPTION
#343 Pull Request

## What

- chattingPanel의 상태 전달 하는 부분의 오타 수정
  isChattingDisabled -> chattingDisabled

- sendChattingHandler에서 정답을 이미 맞힌 유저의 경우
  채팅을 할 수 없도록 수정

- 채팅 정답은 gameManager의 status가 playing일 때만
  맞힐 수 있도록 수정

## Why
- 정답을 이미 맞힌 유저가 계속해서 정답을 맞힐 수 있어서 점수가 비정상 적으로 높은 현상이 발생했기 때문
