### PR TITLE
[develop <- refactor-game-page-index ] Game 페이지 index 리팩토링, 함수분리, 함수위치정리

### DIFF
--- a/client/src/presentation/pages/Game/index.js
+++ b/client/src/presentation/pages/Game/index.js
@@ -84,19 +84,14 @@ const Game = ({ location, match }) => {
     clientManager.toggleReady();
   };
 
-  useEffect(() => {
+  const attachPopstateEvent = () => {
     window.addEventListener(EVENTS.POPSTATE, exitButtonHandler);
     return () => {
       window.removeEventListener(EVENTS.POPSTATE, exitButtonHandler);
     };
-  }, []);
+  };
 
-  useEffect(() => {
-    gameDispatch(actions.setMobileChattingPanelVisibility(currentIsMobile));
-    gameDispatch(actions.setGamePageRootHeight(window.innerHeight));
-  }, [currentIsMobile]);
-
-  useEffect(() => {
+  const showPlayerListByViewShifting = () => {
     if (shiftingToWhichView === MOBILE_VIEW) {
       gameDispatch(actions.setIsPlayerListVisible(false));
       return;
@@ -104,7 +99,20 @@ const Game = ({ location, match }) => {
     if (shiftingToWhichView === DESKTOP_VIEW) {
       gameDispatch(actions.setIsPlayerListVisible(true));
     }
-  }, [shiftingToWhichView]);
+  };
+
+  const dispatchMobileChattingPanelVisibility = () => {
+    gameDispatch(actions.setMobileChattingPanelVisibility(currentIsMobile));
+  };
+
+  const dispatchGamePageRootHeight = () => {
+    gameDispatch(actions.setGamePageRootHeight(window.innerHeight));
+  };
+
+  useEffect(attachPopstateEvent, []);
+  useEffect(dispatchMobileChattingPanelVisibility, [currentIsMobile]);
+  useEffect(dispatchGamePageRootHeight, [currentIsMobile]);
+  useEffect(showPlayerListByViewShifting, [shiftingToWhichView]);
 
   const isGameStatusWaiting = gameStatus === WAITING_STATUS;
 

--- a/client/src/presentation/pages/Game/index.js
+++ b/client/src/presentation/pages/Game/index.js
@@ -39,36 +39,17 @@ const Game = ({ location, match }) => {
     actions,
   });
   const [gameState, gameDispatch] = useReducer(gameReducer, gameInitialState);
-
   const history = useHistory();
   const shiftingToWhichView = useShiftingToWhichView(MOBILE_VIEW_BREAKPOINT);
   const currentIsMobile = useIsMobile(MOBILE_VIEW_BREAKPOINT);
-
+  const classes = useStyles({
+    gamePageRootHeight: gameState.gamePageRootHeight,
+    isPlayerListVisible: gameState.isPlayerListVisible,
+  });
+  const isGameStatusWaiting = gameStatus === WAITING_STATUS;
   const { isPrivateRoomCreation } = location;
   const roomIdFromUrl = match.params.roomId;
-
-  const getMediaPermissionHandler = () => {
-    clientManager.init();
-  };
-
-  const getMediaPermissionErrorHandler = () => {
-    history.push('/');
-    openToast(TOAST_TPYES.INFORMATION, ALLOW_CAMERA_MESSAGE);
-    globalDispatch(actions.setClientManagerInitialized(false));
-  };
-
-  if (!clientManagerInitialized) {
-    clientManager = new ClientManager({
-      history,
-      roomIdFromUrl,
-      isPrivateRoomCreation,
-    });
-    clientManager
-      .getMediaPermission()
-      .then(getMediaPermissionHandler)
-      .catch(getMediaPermissionErrorHandler);
-    globalDispatch(actions.setClientManagerInitialized(true));
-  }
+  const localPlayer = viewPlayerList.find(player => player.isLocalPlayer);
 
   const exitButtonHandler = () => {
     clientManager.exitRoom();
@@ -109,19 +90,33 @@ const Game = ({ location, match }) => {
     gameDispatch(actions.setGamePageRootHeight(window.innerHeight));
   };
 
+  const getMediaPermissionHandler = () => {
+    clientManager.init();
+  };
+
+  const getMediaPermissionErrorHandler = () => {
+    history.push('/');
+    openToast(TOAST_TPYES.INFORMATION, ALLOW_CAMERA_MESSAGE);
+    globalDispatch(actions.setClientManagerInitialized(false));
+  };
+
+  if (!clientManagerInitialized) {
+    clientManager = new ClientManager({
+      history,
+      roomIdFromUrl,
+      isPrivateRoomCreation,
+    });
+    clientManager
+      .getMediaPermission()
+      .then(getMediaPermissionHandler)
+      .catch(getMediaPermissionErrorHandler);
+    globalDispatch(actions.setClientManagerInitialized(true));
+  }
+
   useEffect(attachPopstateEvent, []);
   useEffect(dispatchMobileChattingPanelVisibility, [currentIsMobile]);
   useEffect(dispatchGamePageRootHeight, [currentIsMobile]);
   useEffect(showPlayerListByViewShifting, [shiftingToWhichView]);
-
-  const isGameStatusWaiting = gameStatus === WAITING_STATUS;
-
-  const classes = useStyles({
-    gamePageRootHeight: gameState.gamePageRootHeight,
-    isPlayerListVisible: gameState.isPlayerListVisible,
-  });
-
-  const localPlayer = viewPlayerList.find(player => player.isLocalPlayer);
 
   const gameProps = {
     quiz,

--- a/client/src/presentation/pages/Game/index.js
+++ b/client/src/presentation/pages/Game/index.js
@@ -22,6 +22,25 @@ import { gameReducer, gameState as gameInitialState } from './store';
 
 let clientManager;
 
+const readyButtonHandler = () => {
+  clientManager.toggleReady();
+};
+
+const exitButtonHandler = () => {
+  clientManager.exitRoom();
+};
+
+const getMediaPermissionHandler = () => {
+  clientManager.init();
+};
+
+const attachPopstateEvent = () => {
+  window.addEventListener(EVENTS.POPSTATE, exitButtonHandler);
+  return () => {
+    window.removeEventListener(EVENTS.POPSTATE, exitButtonHandler);
+  };
+};
+
 const Game = ({ location, match }) => {
   const {
     gameStatus,
@@ -51,25 +70,10 @@ const Game = ({ location, match }) => {
   const roomIdFromUrl = match.params.roomId;
   const localPlayer = viewPlayerList.find(player => player.isLocalPlayer);
 
-  const exitButtonHandler = () => {
-    clientManager.exitRoom();
-  };
-
   const showPlayersButtonHandler = () => {
     gameDispatch(
       actions.setIsPlayerListVisible(!gameState.isPlayerListVisible),
     );
-  };
-
-  const readyButtonHandler = () => {
-    clientManager.toggleReady();
-  };
-
-  const attachPopstateEvent = () => {
-    window.addEventListener(EVENTS.POPSTATE, exitButtonHandler);
-    return () => {
-      window.removeEventListener(EVENTS.POPSTATE, exitButtonHandler);
-    };
   };
 
   const showPlayerListByViewShifting = () => {
@@ -88,10 +92,6 @@ const Game = ({ location, match }) => {
 
   const dispatchGamePageRootHeight = () => {
     gameDispatch(actions.setGamePageRootHeight(window.innerHeight));
-  };
-
-  const getMediaPermissionHandler = () => {
-    clientManager.init();
   };
 
   const getMediaPermissionErrorHandler = () => {


### PR DESCRIPTION
# Pull Request

## What
- useEffect 내부의 익명함수를 밖으로 분리
- Game페이지의 index.js의 함수들과 로직의 위치를 타입별로 변경
- Game 페이지 컴포넌트 내부에서 선언하지 않아도 되는 함수를 밖으로 분리
