### PR TITLE
[develop <- refactor-ready-button-visibility] 모바일과 데스크탑의 레디버튼이 실제로 렌더링 되지않게 조건 수정

### DIFF
--- a/client/src/presentation/containers/PlayerPanel.jsx
+++ b/client/src/presentation/containers/PlayerPanel.jsx
@@ -7,6 +7,8 @@ import { PlayerProfile, ReadyButton, ShareUrlButton } from '../components';
 import { shareUrlButtonClickHandler } from '../../utils';
 import styleColors from '../../constants/styleColors';
 import { WAITING_STATUS } from '../../constants/game';
+import useIsMobile from '../../hooks/useIsMobile';
+import { MOBILE_VIEW_BREAKPOINT } from '../../constants/responsiveView';
 
 const useStyle = makeStyles(theme => ({
   playerPanel: {
@@ -45,8 +47,10 @@ const useStyle = makeStyles(theme => ({
 const PlayerPanel = ({ clientManager }) => {
   const classes = useStyle();
   const { viewPlayerList, gameStatus } = useContext(GlobalContext);
+  const currentIsMobile = useIsMobile(MOBILE_VIEW_BREAKPOINT);
   const localPlayer = viewPlayerList.find(player => player.isLocalPlayer);
   const isGameStatusWaiting = gameStatus === WAITING_STATUS;
+  const isReadyButtonVisible = !currentIsMobile && isGameStatusWaiting;
 
   return (
     <Box className={classes.playerPanel}>
@@ -63,7 +67,7 @@ const PlayerPanel = ({ clientManager }) => {
           />
         );
       })}
-      {isGameStatusWaiting && (
+      {isReadyButtonVisible && (
         <Box className={classes.bottomLeftButtonContainer}>
           {clientManager.getIsRoomPrivate() && (
             <ShareUrlButton

--- a/client/src/presentation/pages/Game/index.js
+++ b/client/src/presentation/pages/Game/index.js
@@ -66,6 +66,7 @@ const Game = ({ location, match }) => {
     isPlayerListVisible: gameState.isPlayerListVisible,
   });
   const isGameStatusWaiting = gameStatus === WAITING_STATUS;
+  const isReadyButtonVisible = isGameStatusWaiting && currentIsMobile;
   const { isPrivateRoomCreation } = location;
   const roomIdFromUrl = match.params.roomId;
   const localPlayer = viewPlayerList.find(player => player.isLocalPlayer);
@@ -131,7 +132,7 @@ const Game = ({ location, match }) => {
     mobileChattingPanelVisibility: gameState.mobileChattingPanelVisibility,
     toast,
     closeToast,
-    isGameStatusWaiting,
+    isReadyButtonVisible,
   };
 
   return <GamePresentation gameProps={gameProps} />;

--- a/client/src/presentation/pages/Game/presenter.jsx
+++ b/client/src/presentation/pages/Game/presenter.jsx
@@ -36,7 +36,7 @@ const GamePresentation = ({ gameProps }) => {
     mobileChattingPanelVisibility,
     toast,
     closeToast,
-    isGameStatusWaiting,
+    isReadyButtonVisible,
   } = gameProps;
 
   return (
@@ -106,7 +106,7 @@ const GamePresentation = ({ gameProps }) => {
             className={classes.mobileFullWidth}
             clientManager={clientManager}
           />
-          {isGameStatusWaiting && (
+          {isReadyButtonVisible && (
             <Box className={classes.bottomLeftButtonContainer}>
               {clientManager.getIsRoomPrivate() && (
                 <ShareUrlButton


### PR DESCRIPTION

# Pull Request

## What
- currentIsMobile과 isGameStatusWaiting을 이용하여 isReadyButtonVisible의 조건을 이용하도록 변경
## Etc.
close #506 
