### PR TITLE
[develop <- refactor-server-handlers] 서버사이드 핸들러 리팩토링

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -21,7 +21,7 @@ module.exports = {
   NICKNAME_LENGTH: 8,
   GAME_PLAYING: 'playing',
   GAME_INITIALIZING: 'initializing',
-  GAME_INITIAL_PREPARING: 'initialPreparing',
+  CONNECTING: 'connecting',
   QUIZ_NOT_SELECTED: '',
   INVALID_DATE: 'Invalid Date',
 };

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -157,7 +157,7 @@ const disconnectPlayerSocket = player => {
 
 const disconnectPlayersSocket = players => {
   players.forEach(player => {
-    disconnectPlayer(player);
+    disconnectPlayerSocket(player);
   });
 };
 

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -6,6 +6,7 @@ const {
   SECONDS_BETWEEN_SETS,
   SECONDS_AFTER_GAME_END,
   GAME_PLAYING,
+  CONNECTING,
   QUIZ_NOT_SELECTED,
 } = require('../../../config');
 const {
@@ -278,6 +279,7 @@ const prepareGame = (gameManager, timer) => {
 const goToNextSet = (gameManager, timer) => {
   const roomId = gameManager.getRoomId();
 
+  gameManager.setStatus(CONNECTING);
   sendClearWindowToRoom(roomId);
   preparePlayerTypes(gameManager, timer);
   waitForPeerConnection(gameManager, timer);

--- a/server/service/game/eventHandlers/disconnectingHandler.js
+++ b/server/service/game/eventHandlers/disconnectingHandler.js
@@ -31,13 +31,12 @@ const disconnectingHandler = socket => {
     LeavePlayer(gameManager, socket);
     sendLeftPlayerToRoom(gameManager.getRoomId(), socket.id);
 
-    if (roomStatus === 'waiting') {
-      if (
-        gameManager.checkAllPlayersAreReady() &&
-        gameManager.getPlayers().length >= MIN_PLAYER_COUNT
-      ) {
-        gameController.prepareGame(gameManager, timer);
-      }
+    if (
+      roomStatus === 'waiting' &&
+      gameManager.checkAllPlayersAreReady() &&
+      gameManager.getPlayers().length >= MIN_PLAYER_COUNT
+    ) {
+      gameController.prepareGame(gameManager, timer);
       return;
     }
 

--- a/server/service/game/eventHandlers/disconnectingHandler.js
+++ b/server/service/game/eventHandlers/disconnectingHandler.js
@@ -9,6 +9,17 @@ const {
   MIN_PLAYER_COUNT,
 } = require('../../../config');
 
+const LeavePlayer = (gameManager, socket) => {
+  gameManager.leaveRoom(socket.id);
+  socket.leave(gameManager.getRoomId());
+};
+
+const sendLeftPlayerToRoom = (roomId, socketId) => {
+  io.in(roomId).emit('sendLeftPlayer', {
+    socketId,
+  });
+};
+
 const disconnectingHandler = socket => {
   try {
     const room = roomController.getRoomByRoomId(socket.roomId);
@@ -16,13 +27,9 @@ const disconnectingHandler = socket => {
       return;
     }
     const { gameManager, timer } = room;
-    gameManager.leaveRoom(socket.id);
-    socket.leave(gameManager.getRoomId());
     const roomStatus = gameManager.getStatus();
-
-    io.in(gameManager.getRoomId()).emit('sendLeftPlayer', {
-      socketId: socket.id,
-    });
+    LeavePlayer(gameManager, socket);
+    sendLeftPlayerToRoom(gameManager.getRoomId(), socket.id);
 
     if (roomStatus === 'waiting') {
       if (

--- a/server/service/game/eventHandlers/disconnectingHandler.js
+++ b/server/service/game/eventHandlers/disconnectingHandler.js
@@ -37,7 +37,8 @@ const disconnectingHandler = socket => {
     if (
       roomStatus === GAME_INITIALIZING ||
       roomStatus === GAME_PLAYING ||
-      roomStatus === CONNECTING
+      roomStatus === CONNECTING ||
+      roomStatus === 'scoreSharing'
     ) {
       if (!gameManager.isGameContinuable() || !gameManager.getStreamer()) {
         gameController.repeatSet(gameManager, timer);

--- a/server/service/game/eventHandlers/disconnectingHandler.js
+++ b/server/service/game/eventHandlers/disconnectingHandler.js
@@ -39,16 +39,7 @@ const disconnectingHandler = socket => {
       roomStatus === GAME_PLAYING ||
       roomStatus === GAME_INITIAL_PREPARING
     ) {
-      if (!gameManager.isGameContinuable()) {
-        gameController.endGame(gameManager, timer);
-        gameController.resetGameAfterNSeconds({
-          seconds: SECONDS_AFTER_GAME_END,
-          gameManager,
-          timer,
-        });
-        return;
-      }
-      if (!gameManager.getStreamer()) {
+      if (!gameManager.isGameContinuable() || !gameManager.getStreamer()) {
         gameController.repeatSet(gameManager, timer);
       }
     }

--- a/server/service/game/eventHandlers/disconnectingHandler.js
+++ b/server/service/game/eventHandlers/disconnectingHandler.js
@@ -5,7 +5,7 @@ const {
   SECONDS_AFTER_GAME_END,
   GAME_PLAYING,
   GAME_INITIALIZING,
-  GAME_INITIAL_PREPARING,
+  CONNECTING,
   MIN_PLAYER_COUNT,
 } = require('../../../config');
 
@@ -37,7 +37,7 @@ const disconnectingHandler = socket => {
     if (
       roomStatus === GAME_INITIALIZING ||
       roomStatus === GAME_PLAYING ||
-      roomStatus === GAME_INITIAL_PREPARING
+      roomStatus === CONNECTING
     ) {
       if (!gameManager.isGameContinuable() || !gameManager.getStreamer()) {
         gameController.repeatSet(gameManager, timer);

--- a/server/service/game/eventHandlers/disconnectingHandler.js
+++ b/server/service/game/eventHandlers/disconnectingHandler.js
@@ -2,14 +2,13 @@ const { io } = require('../../io');
 const roomController = require('../controllers/roomController');
 const gameController = require('../controllers/gameController');
 const {
-  SECONDS_AFTER_GAME_END,
   GAME_PLAYING,
   GAME_INITIALIZING,
   CONNECTING,
   MIN_PLAYER_COUNT,
 } = require('../../../config');
 
-const LeavePlayer = (gameManager, socket) => {
+const leavePlayer = (gameManager, socket) => {
   gameManager.leaveRoom(socket.id);
   socket.leave(gameManager.getRoomId());
 };
@@ -28,14 +27,15 @@ const disconnectingHandler = socket => {
     }
     const { gameManager, timer } = room;
     const roomStatus = gameManager.getStatus();
-    LeavePlayer(gameManager, socket);
+    leavePlayer(gameManager, socket);
     sendLeftPlayerToRoom(gameManager.getRoomId(), socket.id);
 
-    if (
+    const isGamePreparable =
       roomStatus === 'waiting' &&
       gameManager.checkAllPlayersAreReady() &&
-      gameManager.getPlayers().length >= MIN_PLAYER_COUNT
-    ) {
+      gameManager.getPlayers().length >= MIN_PLAYER_COUNT;
+
+    if (isGamePreparable) {
       gameController.prepareGame(gameManager, timer);
       return;
     }

--- a/server/service/game/eventHandlers/matchHandler.js
+++ b/server/service/game/eventHandlers/matchHandler.js
@@ -33,13 +33,13 @@ const matchHandler = (
     socketId: socket.id,
     nicknameColor: getRandomColor(),
   });
-  const isRoomPrivate = !!roomIdFromUrl || isPrivateRoomCreation;
-
-  roomController.joinRoom({ socket, roomId, player, isRoomPrivate });
 
   if (roomId) {
-    const room = roomController.getRoomByRoomId(roomId);
-    const otherPlayers = room.gameManager.getOtherPlayers(player.socketId);
+    const isRoomPrivate = !!roomIdFromUrl || isPrivateRoomCreation;
+    roomController.joinRoom({ socket, roomId, player, isRoomPrivate });
+
+    const { gameManager } = roomController.getRoomByRoomId(roomId);
+    const otherPlayers = gameManager.getOtherPlayers(player.socketId);
 
     socket.broadcast.to(roomId).emit('sendNewPlayer', player);
     socket.emit('sendPlayers', { players: otherPlayers });

--- a/server/service/game/eventHandlers/matchHandler.js
+++ b/server/service/game/eventHandlers/matchHandler.js
@@ -35,21 +35,16 @@ const matchHandler = (
   roomController.joinRoom({ socket, roomId, player, isRoomPrivate });
 
   if (roomId) {
-    /**
-     * 새로운 플레이어는 기존 플레이어의 정보들을 전달받고
-     * 기존의 플레이어들은 새로운 플레이어의 정보를 전달받는다.
-     */
     const room = roomController.getRoomByRoomId(roomId);
     const otherPlayers = room.gameManager.getOtherPlayers(player.socketId);
 
     socket.broadcast.to(roomId).emit('sendNewPlayer', player);
     socket.emit('sendPlayers', { players: otherPlayers });
+    emitEventsAfterJoin(socket);
   } else {
     /** @todo 토스터 완성되면 여기서 메인보내고 토스터로 없다고 알려줘야함 */
     socket.disconnect();
-    return;
   }
-  emitEventsAfterJoin(socket);
 };
 
 module.exports = matchHandler;

--- a/server/service/game/eventHandlers/matchHandler.js
+++ b/server/service/game/eventHandlers/matchHandler.js
@@ -9,20 +9,8 @@ const emitEventsAfterJoin = socket => {
   socket.emit(EVENTS.SEND_ROOMID, { roomId: socket.roomId });
 };
 
-const matchHandler = (
-  socket,
-  { nickname, roomIdFromUrl, isPrivateRoomCreation },
-) => {
+const getRoomId = (roomIdFromUrl, isPrivateRoomCreation) => {
   let roomId;
-  const slicedNickname = nickname.slice(0, NICKNAME_LENGTH);
-  const player = new Player({
-    nickname: slicedNickname,
-    socketId: socket.id,
-    nicknameColor: getRandomColor(),
-  });
-
-  const isRoomPrivate = !!roomIdFromUrl || isPrivateRoomCreation;
-
   if (!!roomIdFromUrl || isPrivateRoomCreation) {
     roomId = roomController.getPrivateRoomInformationToJoin(
       roomIdFromUrl,
@@ -31,6 +19,21 @@ const matchHandler = (
   } else {
     roomId = roomController.getPublicRoomInformantionToJoin();
   }
+  return roomId;
+};
+
+const matchHandler = (
+  socket,
+  { nickname, roomIdFromUrl, isPrivateRoomCreation },
+) => {
+  const roomId = getRoomId(roomIdFromUrl, isPrivateRoomCreation);
+  const slicedNickname = nickname.slice(0, NICKNAME_LENGTH);
+  const player = new Player({
+    nickname: slicedNickname,
+    socketId: socket.id,
+    nicknameColor: getRandomColor(),
+  });
+  const isRoomPrivate = !!roomIdFromUrl || isPrivateRoomCreation;
 
   roomController.joinRoom({ socket, roomId, player, isRoomPrivate });
 

--- a/server/service/game/eventHandlers/sendChattingMessageHandler.js
+++ b/server/service/game/eventHandlers/sendChattingMessageHandler.js
@@ -3,10 +3,6 @@ const { io } = require('../../io');
 const { processChatWithSystemRule } = require('../../../utils/chatUtils');
 const roomController = require('../controllers/roomController');
 const gameController = require('../controllers/gameController');
-const {
-  SECONDS_BETWEEN_SETS,
-  SECONDS_AFTER_GAME_END,
-} = require('../../../config');
 
 /**
  * viewer가 입력한 채팅이 정답이라면 true를 반환하는 함수

--- a/server/service/game/models/GameManager.js
+++ b/server/service/game/models/GameManager.js
@@ -1,7 +1,7 @@
 const {
   MAX_ROUND_NUMBER,
   MIN_PLAYER_COUNT,
-  GAME_INITIAL_PREPARING,
+  CONNECTING,
 } = require('../../../config');
 
 class GameManager {
@@ -101,7 +101,7 @@ class GameManager {
   prepareGame() {
     this.reset();
     this.setStreamerCandidates();
-    this.status = GAME_INITIAL_PREPARING;
+    this.status = CONNECTING;
   }
 
   updateRoundAndSet() {


### PR DESCRIPTION
# Pull Request

## What
  - [x] isGameContinuable()과 gameManager.getStreamer()
조건을 따로 검사해서 처리하던 로직을 ||(or)로 묶은 뒤 repeatSet에서 통합적으로 처리하도록 변경
  - [x] initialPreparing을 connecting으로 변경
  - [x] goToNextSet에서 게임의 상태를 connecting으로 변경
  - [x] 게임 상태 "scoreSharing"에 대한 disconnectingHandler처리 로직 추가
  - [x] disconnectHandler의 로직 함수로 분리
  - [x] disconnectingHandler의 중첩 if문 제거
  - [x] matchHandler의 roomId 생성하는 로직 함수로 분리
  - [x] joinRoom함수를 roomId가 있는 경우에만 실행하도록 변경
  - [x] sendChattingHandler에서 사용하지 않는 상수 제거
  - [x] sendChattingHandler 코드 중복 제거 

## Why
- 코드의 중복 제거 및 가독성 개선을 위함