### PR TITLE
[develop <- fix toast rerendering bug] Toast 재렌더링 버그 수정

### DIFF
--- a/client/src/presentation/pages/Game/index.js
+++ b/client/src/presentation/pages/Game/index.js
@@ -17,7 +17,6 @@ import useStyles from './style';
 import useShiftingToWhichView from '../../../hooks/useShiftingToWhichView';
 import useIsMobile from '../../../hooks/useIsMobile';
 import { TOAST_TPYES } from '../../../constants/toast';
-import EVENTS from '../../../constants/events';
 import { gameReducer, gameState as gameInitialState } from './store';
 
 let clientManager;
@@ -32,13 +31,6 @@ const exitButtonHandler = () => {
 
 const getMediaPermissionHandler = () => {
   clientManager.init();
-};
-
-const attachPopstateEvent = () => {
-  window.addEventListener(EVENTS.POPSTATE, exitButtonHandler);
-  return () => {
-    window.removeEventListener(EVENTS.POPSTATE, exitButtonHandler);
-  };
 };
 
 const Game = ({ location, match }) => {
@@ -74,6 +66,13 @@ const Game = ({ location, match }) => {
     gameDispatch(
       actions.setIsPlayerListVisible(!gameState.isPlayerListVisible),
     );
+  };
+
+  const gamePageLifecycleHandler = () => {
+    closeToast();
+    return () => {
+      clientManager.exitRoom();
+    };
   };
 
   const showPlayerListByViewShifting = () => {
@@ -113,7 +112,7 @@ const Game = ({ location, match }) => {
     globalDispatch(actions.setClientManagerInitialized(true));
   }
 
-  useEffect(attachPopstateEvent, []);
+  useEffect(gamePageLifecycleHandler, []);
   useEffect(dispatchMobileChattingPanelVisibility, [currentIsMobile]);
   useEffect(dispatchGamePageRootHeight, [currentIsMobile]);
   useEffect(showPlayerListByViewShifting, [shiftingToWhichView]);

--- a/client/src/presentation/pages/MainPage.jsx
+++ b/client/src/presentation/pages/MainPage.jsx
@@ -41,9 +41,12 @@ const MainPage = () => {
     actions,
   });
 
-  useEffect(() => {
+  const mainPageLifecycleHandler = () => {
+    closeToast();
     browserLocalStorage.verifyNicknameInLocalStorage();
-  }, []);
+  };
+
+  useEffect(mainPageLifecycleHandler, []);
 
   return (
     <Box className={classes.mainPageWrapper}>


### PR DESCRIPTION
# Pull Request

## What

- Main, Game lifecycle을 이용한 toast 컨트롤
- Game 페이지
  - didMount : closeToast
  - didUnmount : exitRoom
- Main 페에지
  - didMount : closeToast

## Why

- 각 페이지 진입 시 toast 컴포넌트 close해줌
- Game 페이지에서 나갈때, disconnect 이벤트가 호출되지 않았음
