### PR TITLE
[ develop <- fix-gamepage-react-lifecycle ] Play with friends 기능에 접근 불가한 버그 수정

### DIFF
--- a/client/src/constants/events.js
+++ b/client/src/constants/events.js
@@ -30,6 +30,7 @@ const EVENTS = {
   SEND_ROOMID: 'sendRoomId',
   // DOM events
   RESIZE: 'resize',
+  POPSTATE: 'popstate',
   // 밑의 이벤트 맞는 곳으로 이동 필요
   RESET_GAME: 'resetGame',
   CLEAR_WINDOW: 'clearWindow',

--- a/client/src/presentation/pages/Game/index.js
+++ b/client/src/presentation/pages/Game/index.js
@@ -78,7 +78,6 @@ const Game = ({ location, match }) => {
 
   const attachPopstateEvent = () => {
     window.addEventListener(EVENTS.POPSTATE, popstateHandler);
-
     return () => {
       return window.addEventListener(EVENTS.POPSTATE, popstateHandler);
     };
@@ -121,6 +120,7 @@ const Game = ({ location, match }) => {
     globalDispatch(actions.setClientManagerInitialized(true));
   }
 
+  useEffect(closeToast, []);
   useEffect(attachPopstateEvent, []);
   useEffect(dispatchMobileChattingPanelVisibility, [currentIsMobile]);
   useEffect(dispatchGamePageRootHeight, [currentIsMobile]);

--- a/client/src/presentation/pages/Game/index.js
+++ b/client/src/presentation/pages/Game/index.js
@@ -20,6 +20,7 @@ import useIsMobile from '../../../hooks/useIsMobile';
 import { TOAST_TYPES } from '../../../constants/toast';
 import { gameReducer, gameState as gameInitialState } from './store';
 import LINK_PATH from '../../../constants/path';
+import EVENTS from '../../../constants/events';
 
 let clientManager;
 
@@ -71,10 +72,15 @@ const Game = ({ location, match }) => {
     );
   };
 
-  const gamePageLifecycleHandler = () => {
-    closeToast();
+  const popstateHandler = () => {
+    clientManager.exitRoom();
+  };
+
+  const attachPopstateEvent = () => {
+    window.addEventListener(EVENTS.POPSTATE, popstateHandler);
+
     return () => {
-      clientManager.exitRoom();
+      return window.addEventListener(EVENTS.POPSTATE, popstateHandler);
     };
   };
 
@@ -114,7 +120,8 @@ const Game = ({ location, match }) => {
       .catch(getMediaPermissionErrorHandler);
     globalDispatch(actions.setClientManagerInitialized(true));
   }
-  useEffect(gamePageLifecycleHandler, []);
+
+  useEffect(attachPopstateEvent, []);
   useEffect(dispatchMobileChattingPanelVisibility, [currentIsMobile]);
   useEffect(dispatchGamePageRootHeight, [currentIsMobile]);
   useEffect(showPlayerListByViewShifting, [shiftingToWhichView]);

--- a/client/src/presentation/pages/Game/index.js
+++ b/client/src/presentation/pages/Game/index.js
@@ -74,13 +74,11 @@ const Game = ({ location, match }) => {
 
   const popstateHandler = () => {
     clientManager.exitRoom();
+    window.removeEventListener(EVENTS.POPSTATE, popstateHandler);
   };
 
   const attachPopstateEvent = () => {
     window.addEventListener(EVENTS.POPSTATE, popstateHandler);
-    return () => {
-      return window.addEventListener(EVENTS.POPSTATE, popstateHandler);
-    };
   };
 
   const showPlayerListByViewShifting = () => {

--- a/client/src/service/ClientManager.js
+++ b/client/src/service/ClientManager.js
@@ -83,7 +83,7 @@ class ClientManager {
   sendRoomIdHandler({ roomId }) {
     this.localPlayer.roomId = roomId;
     if (this.isRoomPrivate) {
-      this.history.push({
+      this.history.replace({
         pathname: `${LINK_PATH.GAME_PAGE}/${roomId}`,
         isPrivateRoomCreation: this.isPrivateRoomCreation,
       });


### PR DESCRIPTION
# Pull Request

## What
- play with friends에서 뒤로가기를 누르면 한번에 메인페이지 못가는 버그 수정
  - history.push를 history.replace로 바꿈으로써 history에서 가장 상단의 기록을 쌓는게 아니라 바꾸는 방식으로 바꿈 -> 뒤로가기 한번이면 다시 메인으로 이동 가능


- 브라우저 popstate가 일어나면 clientManger가 exitRoom을 확실히 하도록 변경

  - popstate이벤트에 clientManager가 exitRoom을 하여 다음 진입에도 clientManager가 다시 init 할 수 있도록 함
  - gamePageLifeCycleHandler에서 attachPopstateEvent라고 수정
  - attachPopstateEvent에서 정리함수를 통해 eventRemove를 함
  - 뒤로가기 버튼을 클릭시 popstate event가 발생하는 것 확인
  - Play with friends에서 새로고침시 popstate 발생안함 -> 안하는 것이 맞음
  - Play with friends에서 새로고침시 만약 혼자라면 방이 사라지기때문에 disconnect되어 뒤로 이동되는 것으로 확인 -> 맞는 동작

- 전 페이지의 남아있는 toast를 제거하는 로직 추가
  - 내부적으로 글로벌 상태를 변경하는 closeToast를 useEfffect에 []를 두번째 인자로 추가하여 적용함

## Etc.
- #515, #516, #517
