### PR TITLE
[develop <- fix-server-handler]

### DIFF
--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -222,6 +222,7 @@ const prepareQuizSelection = async (gameManager, timer) => {
 };
 
 const prepareSet = async (gameManager, timer) => {
+  gameManager.setStatus(INITIALIZING);
   gameManager.updateRoundAndSet();
   gameManager.setQuiz(GAME_RULE.DEFAULT_QUIZ);
 

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -236,11 +236,12 @@ const disconnectPlayersAndStartGame = (gameManager, timer) => {
   const isAllPlayerWebRTCDisconnected =
     playersToDisconnect.length === viewers.length;
 
+  // viewer전체가 연결되지 않은 경우 streamer에게 문제가 있다고 가정
   if (isAllPlayerWebRTCDisconnected) {
     disconnectPlayerSocket(streamer);
   } else {
     disconnectPlayersSocket(playersToDisconnect);
-    if (gameManager.isGameContinuable()) {
+    if (gameManager.isSetContinuable()) {
       prepareSet(gameManager, timer);
     }
   }
@@ -320,7 +321,7 @@ const resetGameAfterNSeconds = ({ seconds, gameManager, timer }) => {
 };
 
 const repeatSet = (gameManager, timer) => {
-  if (gameManager.isGameContinuable()) {
+  if (gameManager.isNextSetAvailable()) {
     endSet(gameManager, timer);
     goToNextSetAfterNSeconds({
       seconds: GAME_RULE.SECONDS_BETWEEN_SETS,

--- a/server/service/game/controllers/gameController.js
+++ b/server/service/game/controllers/gameController.js
@@ -222,7 +222,7 @@ const prepareQuizSelection = async (gameManager, timer) => {
 };
 
 const prepareSet = async (gameManager, timer) => {
-  gameManager.setStatus(INITIALIZING);
+  gameManager.setStatus(GAME_STATUS.INITIALIZING);
   gameManager.updateRoundAndSet();
   gameManager.setQuiz(GAME_RULE.DEFAULT_QUIZ);
 

--- a/server/service/game/eventHandlers/connectPeerHandler.js
+++ b/server/service/game/eventHandlers/connectPeerHandler.js
@@ -1,6 +1,6 @@
 const roomController = require('../controllers/roomController');
 const gameController = require('../controllers/gameController');
-const { INITIALIZING } = require('../../../constants/gameStatus');
+const GAME_STATUS = require('../../../constants/gameStatus');
 
 const connectPeerHandler = socket => {
   const { gameManager, timer } = roomController.getRoomByRoomId(socket.roomId);
@@ -10,7 +10,7 @@ const connectPeerHandler = socket => {
   if (
     gameManager.getStreamer() &&
     gameManager.checkAllConnectionsToStreamer() &&
-    gameManager.getStatus() !== INITIALIZING
+    gameManager.getStatus() !== GAME_STATUS.INITIALIZING
   ) {
     /**
      * 연결 준비 후 정상 시작

--- a/server/service/game/eventHandlers/connectPeerHandler.js
+++ b/server/service/game/eventHandlers/connectPeerHandler.js
@@ -15,7 +15,6 @@ const connectPeerHandler = socket => {
     /**
      * 연결 준비 후 정상 시작
      */
-    gameManager.setStatus(INITIALIZING);
     timer.clear();
     gameController.prepareSet(gameManager, timer);
   }

--- a/server/service/game/eventHandlers/disconnectingHandler.js
+++ b/server/service/game/eventHandlers/disconnectingHandler.js
@@ -19,7 +19,6 @@ const sendLeftPlayerToRoom = (roomId, socketId) => {
 const disconnectingHandler = socket => {
   try {
     const room = roomController.getRoomByRoomId(socket.roomId);
-    console.log('disconnectingHandler :', room);
     if (!room) {
       return;
     }
@@ -44,7 +43,7 @@ const disconnectingHandler = socket => {
       roomStatus === GAME_STATUS.CONNECTING ||
       roomStatus === GAME_STATUS.SCORE_SHARING
     ) {
-      if (!gameManager.isGameContinuable() || !gameManager.getStreamer()) {
+      if (!gameManager.isSetContinuable()) {
         gameController.repeatSet(gameManager, timer);
       }
     }

--- a/server/service/game/models/GameManager.js
+++ b/server/service/game/models/GameManager.js
@@ -221,9 +221,13 @@ class GameManager {
     return this.players.every(player => player.getIsReady());
   }
 
-  isGameContinuable() {
+  isSetContinuable() {
+    return this.streamer && this.players.length >= MIN_PLAYER_COUNT;
+  }
+
+  isNextSetAvailable() {
     return (
-      this.getStreamerCandidates().flat().length > 0 &&
+      this.streamerCandidates.flat().length > 0 &&
       this.currentRound <= MAX_ROUND_NUMBER &&
       this.players.length >= MIN_PLAYER_COUNT
     );

--- a/server/service/game/models/GameManager.js
+++ b/server/service/game/models/GameManager.js
@@ -151,13 +151,13 @@ class GameManager {
 
     this.removeStreamerCandidate(socketId);
 
-    if (this.streamer && this.isStreamer(socketId)) {
+    if (this.isStreamer(socketId)) {
       this.streamer = null;
     }
   }
 
   isStreamer(socketId) {
-    return this.streamer.socketId === socketId;
+    return this.streamer && this.streamer.socketId === socketId;
   }
 
   removeStreamerCandidate(socketId) {


### PR DESCRIPTION
# Pull Request

## What
- prepareSet함수내에서 게임 상태를 initializing으로 변경하도록 수정
- 마지막 세트 진행중 viewer가 나가면 그대로 게임이 종료되는 버그 수정
- INITIALIZING을 GAME_STATUS에서 빼서 쓰도록 변경
- gameManager의 isStreamer함수 내에서 null 체크 로직 추가

## Why
- 마지막 세트 진행중 viewer가 나가면 그대로 게임이 종료되는 버그 발생