### PR TITLE
[develop <- refactor ranking page] exhaustive-deps lint rule 적용

### DIFF
--- a/client/src/presentation/pages/Ranking/index.js
+++ b/client/src/presentation/pages/Ranking/index.js
@@ -47,35 +47,41 @@ const Ranking = () => {
   /**
    * offset이 변경되면 서버에 랭킹 데이터 요청 후 렌더링
    */
-  const setRankingLists = async () => {
-    setMoreButtonLock(true);
-    setLoading(true);
+  const setRankingLists = () => {
+    const executeSetRankingLists = async () => {
+      setMoreButtonLock(true);
+      setLoading(true);
 
-    const rankingsData = await getRankings(offset, currentDateTime);
-    const rankingList = rankingsData.map((ranking, index) => {
-      return {
-        rank: `${index + 1 + topRankingList.length + bottomRankingList.length}`,
-        nickname: ranking.nickname,
-        score: `${ranking.score}`,
-      };
-    });
-    setTimeout(async () => {
-      if (offset === 0) {
-        const rankingInformaion = await getRankingInformation();
-        setRankingCount(rankingInformaion.rankingCount);
-        setCurrentDateTime(rankingInformaion.currentTime);
-        setTopRankingList(getTopRankingList(rankingList));
-        setBottomRankingList(getBottomRankingList(rankingList));
-        setIsBottomRankingVisible(true);
-      } else {
-        setBottomRankingList([...bottomRankingList, ...rankingList]);
-      }
-      setLoading(false);
-      setMoreButtonLock(false);
-    }, 500);
+      const rankingsData = await getRankings(offset, currentDateTime);
+      const rankingList = rankingsData.map((ranking, index) => {
+        return {
+          rank: `${index +
+            1 +
+            topRankingList.length +
+            bottomRankingList.length}`,
+          nickname: ranking.nickname,
+          score: `${ranking.score}`,
+        };
+      });
+      setTimeout(async () => {
+        if (offset === 0) {
+          const rankingInformaion = await getRankingInformation();
+          setRankingCount(rankingInformaion.rankingCount);
+          setCurrentDateTime(rankingInformaion.currentTime);
+          setTopRankingList(getTopRankingList(rankingList));
+          setBottomRankingList(getBottomRankingList(rankingList));
+          setIsBottomRankingVisible(true);
+        } else {
+          setBottomRankingList([...bottomRankingList, ...rankingList]);
+        }
+        setLoading(false);
+        setMoreButtonLock(false);
+      }, 500);
+    };
+    executeSetRankingLists();
   };
 
-  useEffect(() => {
+  const validateAllRankingsFetched = () => {
     /**
      * 모든 랭킹 데이터를 가져왔을때, 버튼과 loading 컴포넌트를 제거하고
      * api 요청은 lock을 걸어 놓음
@@ -89,10 +95,10 @@ const Ranking = () => {
         setIsMoreButtomVisibile(false);
       }, 0);
     }
-  }, [bottomRankingList, rankingCount]);
-  useEffect(() => {
-    setRankingLists();
-  }, [offset]);
+  };
+
+  useEffect(validateAllRankingsFetched, [bottomRankingList, rankingCount]);
+  useEffect(setRankingLists, [offset]);
 
   return (
     <Box className={classes.mainPageWrapper}>


### PR DESCRIPTION
# Pull Request

## What

- useEffect에서 사용되는 상태를 []에 할당해줘야해서
  callback으로 전달

## Why

- https://github.com/facebook/react/issues/14920

## Etc.

- callback으로 바꿔도 결국 같은 상태인데 warning이 사라짐
  추가적인 조사가 필요함
- callback 함수로 묶는 간단한 작업이므로 바로 병합
