### PR TITLE
[develop <- refactor-move-usecontext-to-top ] Manager들 useContext모두 제거

### DIFF
--- a/client/src/presentation/pages/Game/index.js
+++ b/client/src/presentation/pages/Game/index.js
@@ -110,6 +110,8 @@ const Game = ({ location, match }) => {
       history,
       roomIdFromUrl,
       isPrivateRoomCreation,
+      dispatch: globalDispatch,
+      toast,
     });
     clientManager
       .getMediaPermission()

--- a/client/src/service/ChattingManager.js
+++ b/client/src/service/ChattingManager.js
@@ -1,6 +1,4 @@
 /* eslint-disable class-methods-use-this */
-import { useContext } from 'react';
-import { DispatchContext } from '../contexts';
 import { MAX_CHAT_LENGTH } from '../constants/inputConstraints';
 import EVENTS from '../constants/events';
 import { WELCOME_MESSAGE } from '../constants/chatting';
@@ -11,8 +9,8 @@ import {
 import actions from '../actions/global';
 
 class ChattingManager {
-  constructor(socket, isRoomPrivate) {
-    this.dispatch = useContext(DispatchContext);
+  constructor(socket, isRoomPrivate, dispatch) {
+    this.dispatch = dispatch;
     this.socket = socket;
     this.isAvailableChatting = false;
     this.isRoomPrivate = isRoomPrivate;

--- a/client/src/service/ClientManager.js
+++ b/client/src/service/ClientManager.js
@@ -1,6 +1,4 @@
 import io from 'socket.io-client';
-import { useContext } from 'react';
-import { DispatchContext } from '../contexts';
 import GameManager from './GameManager';
 import StreamingManager from './StreamingManager';
 import ChattingManager from './ChattingManager';
@@ -14,7 +12,13 @@ import LINK_PATH from '../constants/path';
 import { LOCALSTORAGE_DEFAULT_NICKNAME } from '../constants/browser';
 
 class ClientManager {
-  constructor({ history, roomIdFromUrl, isPrivateRoomCreation }) {
+  constructor({
+    history,
+    roomIdFromUrl,
+    isPrivateRoomCreation,
+    dispatch,
+    toast,
+  }) {
     this.history = history;
     this.localPlayer = {
       isReady: false,
@@ -28,19 +32,26 @@ class ClientManager {
     this.isPrivateRoomCreation = isPrivateRoomCreation;
     this.socket = io(SOCKETIO_SERVER_URL);
     this.remotePlayers = {};
+    this.dispatch = dispatch;
     this.gameManager = new GameManager({
       socket: this.socket,
       localPlayer: this.localPlayer,
       remotePlayers: this.remotePlayers,
       isRoomPrivate: this.isRoomPrivate,
+      dispatch,
+      toast,
     });
     this.streamingManager = new StreamingManager(
       this.socket,
       this.remotePlayers,
       this.localPlayer,
+      dispatch,
     );
-    this.chattingManager = new ChattingManager(this.socket, this.isRoomPrivate);
-    this.dispatch = useContext(DispatchContext);
+    this.chattingManager = new ChattingManager(
+      this.socket,
+      this.isRoomPrivate,
+      dispatch,
+    );
   }
 
   registerSocketEvents() {

--- a/client/src/service/GameManager.js
+++ b/client/src/service/GameManager.js
@@ -1,5 +1,3 @@
-import { useContext } from 'react';
-import { DispatchContext, GlobalContext } from '../contexts';
 import { makeViewPlayerList } from '../utils';
 import { WAITING_FOR_STREAMER } from '../constants/message';
 import EVENTS from '../constants/events';
@@ -14,14 +12,20 @@ import {
 import { GAME_STATUS } from '../constants/game';
 
 class GameManager {
-  constructor({ socket, localPlayer, remotePlayers, isRoomPrivate }) {
-    this.dispatch = useContext(DispatchContext);
+  constructor({
+    socket,
+    localPlayer,
+    remotePlayers,
+    isRoomPrivate,
+    dispatch,
+    toast,
+  }) {
+    this.dispatch = dispatch;
     this.socket = socket;
     this.remotePlayers = remotePlayers;
     this.localPlayer = localPlayer;
     this.timer = new Timer();
     this.isRoomPrivate = isRoomPrivate;
-    const { toast } = useContext(GlobalContext);
     this.toast = toast;
   }
 

--- a/client/src/service/StreamingManager.js
+++ b/client/src/service/StreamingManager.js
@@ -1,5 +1,3 @@
-import { useContext } from 'react';
-import { DispatchContext } from '../contexts';
 import WebRTCManager from './WebRTCManager';
 import { makeViewPlayerList } from '../utils';
 import EVENTS from '../constants/events';
@@ -8,8 +6,8 @@ import { PLAYER_TYPES } from '../constants/game';
 import { DESCRIPTION_TYPE } from '../constants/webRTC';
 
 class StreamingManager {
-  constructor(socket, remotePlayers, localPlayer) {
-    this.dispatch = useContext(DispatchContext);
+  constructor(socket, remotePlayers, localPlayer, dispatch) {
+    this.dispatch = dispatch;
     this.socket = socket;
     this.localPlayer = localPlayer;
     this.remotePlayers = remotePlayers;


### PR DESCRIPTION

# Pull Request

## What
- ClientManager, GameManager, ChattingManager, StreamingManager의 useContext를 모두 제거하고
  Game/index의 dispatch와 state를 가져와 사용하도록 변경

## Why
- hooks api의 권고사항을 반영하기 위해서
- 나중에 나타날 sideeffect를 제거하기위해

## Etc.
close #532
